### PR TITLE
V202342 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ The author(s) will try to keep this integration working, but cannot provide tech
 11. Search for "Span"
 12. Enter the IP of your Span Panel to begin setup
 
+The setup flow has two methods available, either the "proximity" method where one presses the door button 3 times to "unlock" the panel's API, or a new method leveraging an authorization token.
+
+### Method 1:
+Simply open the door to your Span Panel and press the door sensor button 3 times in succession. The lights ringing the frame of your panel should blink momentarily, and the Panel will now be "unlocked" for 15 minutes (It may in fact be significantly longer, but 15 is the documented period.)
+
+You can now simply proceed with the "Manual" flow in the UI menu.
+
+_Please note that this method is scheduled by Span to be deprecated at an unknown point in the future in favor of Method 2_
+
+### Method 2:
+
+This method, at this time, will require some base knowledge of making direct calls to an API endpoint with JSON data via a CLI or custom tool. There is a long-term goal to eventually move this logic into the configuration UI behind the scenes, to avoid the need to do this manually yourself.
+
+1. Make a POST to {Span_Panel_IP}`/api/v1/auth/register` with a JSON body of `{"name": "home-assistant-UNIQUEID", "description": "Home Assistant Local Span Integration"}`.
+
+    * Use a unique value for UNIQUEID. Six random alphanumeric characters would be a reasonable choice. If the name conflicts with one that's already been created, then the request will fail.
+
+2. If the panel is already "unlocked", you will get a 2xx response to this call containing the `"accessToken"`. If not, then you will be prompted to open and close the door of the panel 3 times, once every two seconds, and then retry the query.
+
+3. Store the value from the `"accessToken"` property of the response. (It will be a long string, such as `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"` for example). This is the token which should be included with all future requests.
+
+4. Send all future requests with the HTTP header `"Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"` (Remember, this is just a dummy example token!)
+
+_(If you have multiple Span Panels, you will need to repeat this process for each panel, as tokens are only accepted by the panel that generated them.)_
+
+You can now proceed with the "Auth Token" flow in the UI menu.
+
 # Devices & Entities
 
 This integration will a device for your span panel.

--- a/README.md
+++ b/README.md
@@ -20,20 +20,18 @@ The author(s) will try to keep this integration working, but cannot provide tech
 8. Click `Devices & Services`
 10. Click `+ Add Integration`
 11. Search for "Span"
-12. Enter the IP of your Span Panel to begin setup
+12. Enter the IP of your Span Panel to begin setup, or select the automatically discovered panel if it shows up.
 
-The setup flow has two methods available, either the "proximity" method where one presses the door button 3 times to "unlock" the panel's API, or a new method leveraging an authorization token.
+The span api requires an auth token. If you already have one from some previous setup, you can reuse it. If you don't already have a token (most people), you just need to prove that you are physically near the panel, and then the integration can get its own token.
 
-### Method 1:
-Simply open the door to your Span Panel and press the door sensor button 3 times in succession. The lights ringing the frame of your panel should blink momentarily, and the Panel will now be "unlocked" for 15 minutes (It may in fact be significantly longer, but 15 is the documented period.)
+### Proof of Proximity:
+Simply open the door to your Span Panel and press the door sensor button 3 times in succession. The lights ringing the frame of your panel should blink momentarily, and the Panel will now be "unlocked" for 15 minutes (It may in fact be significantly longer, but 15 is the documented period.) While the panel is unlocked, it will allow the integration to create a new auth token. 
 
-You can now simply proceed with the "Manual" flow in the UI menu.
+### Authentication details:
 
-_Please note that this method is scheduled by Span to be deprecated at an unknown point in the future in favor of Method 2_
+These details were provided by a SPAN engineer, and have been implemented in the integration. They are documented here in the hope someone may find them useful.
 
-### Method 2:
-
-This method, at this time, will require some base knowledge of making direct calls to an API endpoint with JSON data via a CLI or custom tool. There is a long-term goal to eventually move this logic into the configuration UI behind the scenes, to avoid the need to do this manually yourself.
+To get an auth token:
 
 1. Make a POST to {Span_Panel_IP}`/api/v1/auth/register` with a JSON body of `{"name": "home-assistant-UNIQUEID", "description": "Home Assistant Local Span Integration"}`.
 
@@ -49,7 +47,7 @@ This method, at this time, will require some base knowledge of making direct cal
 
 _(If you have multiple Span Panels, you will need to repeat this process for each panel, as tokens are only accepted by the panel that generated them.)_
 
-You can now proceed with the "Auth Token" flow in the UI menu.
+If you have this auth token, you can entere it in the "Existing Auth Token" flow in the UI menu.
 
 # Devices & Entities
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ The author(s) will try to keep this integration working, but cannot provide tech
 # Installation
 
 1. Install [HACS](https://hacs.xyz/)
-2. Go to HACS `Integrations >` section
-3. In the uppper right click `...`
-4. Select `Custom Repositories`
-5. Set `Repository` to "gdgib/span" and `Category` to "Integration, then click `Add`
-6. Add the "Span Panel" integration
+2. Go to HACS `Integrations` section
+3. In the lower right click "Explore & Download Repositories"
+4. Search for `Span`
+5. Select the "Span Panel" result
+6. Select "Download"
 7. Restart Home Assistant
 7. In the Home Assistant UI go to `Settings`
 8. Click `Devices & Services`
 10. Click `+ Add Integration`
 11. Search for "Span"
+12. Enter the IP of your Span Panel to begin setup
 
 # Devices & Entities
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This method, at this time, will require some base knowledge of making direct cal
 1. Make a POST to {Span_Panel_IP}`/api/v1/auth/register` with a JSON body of `{"name": "home-assistant-UNIQUEID", "description": "Home Assistant Local Span Integration"}`.
 
     * Use a unique value for UNIQUEID. Six random alphanumeric characters would be a reasonable choice. If the name conflicts with one that's already been created, then the request will fail.
+  
+    Example via CLI: `curl -X POST https://192.168.1.2/api/v1/auth/register -H 'Content-Type: application/json' -d '{"name": "home-assistant-123456", "description": "Home Assistant Local Span Integration"}'`
 
 2. If the panel is already "unlocked", you will get a 2xx response to this call containing the `"accessToken"`. If not, then you will be prompted to open and close the door of the panel 3 times, once every two seconds, and then retry the query.
 

--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -173,8 +173,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_menu(
             step_id="choose_auth_type",
             menu_options={
-                "auth_proximity": "Manual",
-                "auth_token": "Auth Token",
+                "auth_proximity": "Proof of Proximity (recommended)",
+                "auth_token": "Existing Auth Token",
             },
         )
 

--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -191,11 +191,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         panel_status = await span_api.get_status_data()
 
         # Reprompt until we are able to do proximity auth
-        remaining_presses = panel_status.remaining_auth_unlock_button_presses
-        if remaining_presses != 0:
+        proximity_verified = panel_status.proximity_proven
+        if proximity_verified is False:
             return self.async_show_form(
-                step_id="auth_proximity",
-                description_placeholders={"remaining": remaining_presses},
+                step_id="auth_proximity"
             )
 
         # Ensure token is valid

--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -171,10 +171,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.ensure_flow_is_set_up()
 
         return self.async_show_menu(
-            step_id="auth_menu",
+            step_id="choose_auth_type",
             menu_options={
-                "auth_proximity",
-                "auth_token",
+                "auth_proximity": "Manual",
+                "auth_token": "Auth Token",
             },
         )
 

--- a/custom_components/span_panel/span_panel_status.py
+++ b/custom_components/span_panel/span_panel_status.py
@@ -14,7 +14,7 @@ class SpanPanelStatus:
     serial_number: str
     model: str
     door_state: str
-    remaining_auth_unlock_button_presses: int
+    proximity_proven: bool
     uptime: int
     is_ethernet_connected: bool
     is_wifi_connected: bool
@@ -34,9 +34,7 @@ class SpanPanelStatus:
             serial_number=data["system"]["serial"],
             model=data["system"]["model"],
             door_state=data["system"]["doorState"],
-            remaining_auth_unlock_button_presses=data["system"][
-                "remainingAuthUnlockButtonPresses"
-            ],
+            proximity_proven=data["system"]["proximityProven"],
             uptime=data["system"]["uptime"],
             is_ethernet_connected=data["network"]["eth0Link"],
             is_wifi_connected=data["network"]["wlanLink"],

--- a/custom_components/span_panel/span_panel_status.py
+++ b/custom_components/span_panel/span_panel_status.py
@@ -27,7 +27,6 @@ class SpanPanelStatus:
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "SpanPanelStatus":
-
         if "proximityProven" in data["system"]:
             sps = SpanPanelStatus(
                 firmware_version=data["software"]["firmwareVersion"],

--- a/custom_components/span_panel/strings.json
+++ b/custom_components/span_panel/strings.json
@@ -22,7 +22,7 @@
                 },
                 "title": "Connect to the Span Panel"
             },
-            "auth_menu": {
+            "choose_auth_type": {
                 "title": "Choose Authentication Options",
                 "menu_options": {
                     "auth_proximity": "Authenticate through your physical Span Panel",

--- a/custom_components/span_panel/strings.json
+++ b/custom_components/span_panel/strings.json
@@ -31,7 +31,7 @@
             },
             "auth_proximity": {
                 "title": "Proximity Authentication",
-                "description": "Please open and close the Span Panel door {remaining} times."
+                "description": "Please open and close the Span Panel door 3 times."
             },
             "auth_token": {
                 "title": "Manual Token Authentication",

--- a/custom_components/span_panel/translations/en.json
+++ b/custom_components/span_panel/translations/en.json
@@ -22,7 +22,7 @@
                 },
                 "title": "Connect to the Span Panel"
             },
-            "auth_menu": {
+            "choose_auth_type": {
                 "title": "Choose Authentication Options",
                 "menu_options": {
                     "auth_proximity": "Authenticate through your physical Span Panel",

--- a/custom_components/span_panel/translations/en.json
+++ b/custom_components/span_panel/translations/en.json
@@ -31,7 +31,7 @@
             },
             "auth_proximity": {
                 "title": "Proximity Authentication",
-                "description": "Please open and close the Span Panel door {remaining} times."
+                "description": "Please open and close the Span Panel door 3 times."
             },
             "auth_token": {
                 "title": "Manual Token Authentication",


### PR DESCRIPTION
This will fix the breaking change in firmware r202342 by adding in support for the `proximityProven` bool alongside the `remainingAuthUnlockButtonPresses` int, so that users who have been updated and those who have not (or people with two panels out of sync) can all continue to operate as expected off of one release base. (ie fixes #21)

Also in fixing this, I discovered there were unreleased changes in `main` that were broken, as `auth_menu` is referenced but not properly defined in `config_flow.py`. I fixed these issues as well, so that a new release cut from main will now work as expected.