### PR TITLE
Clarify authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ The author(s) will try to keep this integration working, but cannot provide tech
 8. Click `Devices & Services`
 10. Click `+ Add Integration`
 11. Search for "Span"
+12. Enter the IP of your Span Panel to begin setup, or select the automatically discovered panel if it shows up.
+
+The span api requires an auth token. If you already have one from some previous setup, you can reuse it. If you don't already have a token (most people), you just need to prove that you are physically near the panel, and then the integration can get its own token.
+
+### Proof of Proximity:
+Simply open the door to your Span Panel and press the door sensor button 3 times in succession. The lights ringing the frame of your panel should blink momentarily, and the Panel will now be "unlocked" for 15 minutes (It may in fact be significantly longer, but 15 is the documented period.) While the panel is unlocked, it will allow the integration to create a new auth token. 
+
+### Authentication details:
+
+These details were provided by a SPAN engineer, and have been implemented in the integration. They are documented here in the hope someone may find them useful.
+
+To get an auth token:
+
+1. Make a POST to {Span_Panel_IP}`/api/v1/auth/register` with a JSON body of `{"name": "home-assistant-UNIQUEID", "description": "Home Assistant Local Span Integration"}`.
+
+    * Use a unique value for UNIQUEID. Six random alphanumeric characters would be a reasonable choice. If the name conflicts with one that's already been created, then the request will fail.
+
+2. If the panel is already "unlocked", you will get a 2xx response to this call containing the `"accessToken"`. If not, then you will be prompted to open and close the door of the panel 3 times, once every two seconds, and then retry the query.
+
+3. Store the value from the `"accessToken"` property of the response. (It will be a long string, such as `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"` for example). This is the token which should be included with all future requests.
+
+4. Send all future requests with the HTTP header `"Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"` (Remember, this is just a dummy example token!)
+
+_(If you have multiple Span Panels, you will need to repeat this process for each panel, as tokens are only accepted by the panel that generated them.)_
+
+If you have this auth token, you can entere it in the "Existing Auth Token" flow in the UI menu.
 
 # Devices & Entities
 

--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -173,8 +173,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_menu(
             step_id="auth_menu",
             menu_options={
-                "auth_proximity",
-                "auth_token",
+                "auth_proximity": "Proof of Proximity (recommended)",
+                "auth_token": "Existing Auth Token",
             },
         )
 


### PR DESCRIPTION
I think you misunderstood the state of authentication. This integration has already implemented the POST process to get its own token. Allowing the user to generate a token for several minutes after proving proximity is not currently scheduled for removal at some future date, as it is an intended use case. I'm not 100% certain, but I believe that the "at some point in the future we will make the panel re-lock itself" I alluded to months and months ago was deployed in the firmware revision that introduced the proximityProven boolean.