### PR TITLE
Fix: updated deprecated constant for UnitOfEnergy and UnitOfPower (fi…

### DIFF
--- a/custom_components/span_panel/sensor.py
+++ b/custom_components/span_panel/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT
 from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -77,7 +77,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_POWER,
         name="Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.POWER,
@@ -86,7 +86,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_ENERGY_PRODUCED,
         name="Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -95,7 +95,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_ENERGY_CONSUMED,
         name="Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -107,7 +107,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="instantGridPowerW",
         name="Current Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
@@ -116,7 +116,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughPowerW",
         name="Feed Through Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
@@ -125,7 +125,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="mainMeterEnergy.producedEnergyWh",
         name="Main Meter Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -134,7 +134,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="mainMeterEnergy.consumedEnergyWh",
         name="Main Meter Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -143,7 +143,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughEnergy.producedEnergyWh",
         name="Feed Through Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -152,7 +152,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughEnergy.consumedEnergyWh",
         name="Feed Through Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,

--- a/custom_components/span_panel/sensor.py
+++ b/custom_components/span_panel/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,


### PR DESCRIPTION
Fixes #41 deprecated constants ENERGY_WATT_HOUR and POWER_WATT replacing these constants with UnitOfEnergy.Watt_HOUR and UnitOfEnergy.WATT