### PR TITLE
Addresses Issue #45 - 500 error on abort in config dialog for auth method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .*sw*
 *.pyc
 /.project
+.DS_Store
+.vscode/settings.json
+.vscode/extensions.json

--- a/custom_components/span_panel/__init__.py
+++ b/custom_components/span_panel/__init__.py
@@ -55,8 +55,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 await span_panel.update()
             except httpx.HTTPStatusError as err:
-                raise ConfigEntryAuthFailed from err
+                if err.response.status_code == 401:
+                    raise ConfigEntryAuthFailed from err
+                else:
+                    _LOGGER.error("An httpx.StatusError occurred while updating Span data: %s", str(err))
+                    raise UpdateFailed(f"Error communicating with API: {err}") from err
             except httpx.HTTPError as err:
+                _LOGGER.error("An httpx.HTTPError occurred while updating Span data: %s", str(err))
+                raise UpdateFailed(f"Error communicating with API: {err}") from err
+            except httpx.TransportError as err:
+                _LOGGER.error("An httpx.Transport error occurred while updating Span data: %s", str(err))
                 raise UpdateFailed(f"Error communicating with API: {err}") from err
 
             return span_panel

--- a/custom_components/span_panel/__init__.py
+++ b/custom_components/span_panel/__init__.py
@@ -1,6 +1,7 @@
 """The Span Panel integration."""
 from __future__ import annotations
 from datetime import timedelta
+from http import HTTPStatus
 
 import logging
 

--- a/custom_components/span_panel/__init__.py
+++ b/custom_components/span_panel/__init__.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 await span_panel.update()
             except httpx.HTTPStatusError as err:
-                if err.response.status_code == 401:
+                if err.response.status_code == HTTPStatus.UNAUTHORIZED:
                     raise ConfigEntryAuthFailed from err
                 else:
                     _LOGGER.error("An httpx.StatusError occurred while updating Span data: %s", str(err))

--- a/custom_components/span_panel/config_flow.py
+++ b/custom_components/span_panel/config_flow.py
@@ -163,12 +163,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        return await self.async_step_choose_auth_type()
+        # Pass the (empty) dictionary to signal the call came from this step, not abort
+        return await self.async_step_choose_auth_type(user_input)
 
     async def async_step_choose_auth_type(
         self,
+        user_input=None 
     ) -> FlowResult:
         self.ensure_flow_is_set_up()
+        
+        # None means this method was called by HA core as an abort
+        if user_input is None:
+            return await self.async_step_confirm_discovery()
 
         return self.async_show_menu(
             step_id="choose_auth_type",

--- a/custom_components/span_panel/sensor.py
+++ b/custom_components/span_panel/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_WATT_HOUR, POWER_WATT
 from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -77,7 +77,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_POWER,
         name="Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.POWER,
@@ -86,7 +86,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_ENERGY_PRODUCED,
         name="Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -95,7 +95,7 @@ CIRCUITS_SENSORS = (
     SpanPanelCircuitsSensorEntityDescription(
         key=CIRCUITS_ENERGY_CONSUMED,
         name="Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -107,7 +107,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="instantGridPowerW",
         name="Current Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
@@ -116,7 +116,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughPowerW",
         name="Feed Through Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
@@ -125,7 +125,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="mainMeterEnergy.producedEnergyWh",
         name="Main Meter Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -134,7 +134,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="mainMeterEnergy.consumedEnergyWh",
         name="Main Meter Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -143,7 +143,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughEnergy.producedEnergyWh",
         name="Feed Through Produced Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
@@ -152,7 +152,7 @@ PANEL_SENSORS = (
     SpanPanelDataSensorEntityDescription(
         key="feedthroughEnergy.consumedEnergyWh",
         name="Feed Through Consumed Energy",
-        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,

--- a/custom_components/span_panel/sensor.py
+++ b/custom_components/span_panel/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,


### PR DESCRIPTION
Addresses issue #45.  Added the required second parameter user_input to the async_step_choose_auth_type method so when HA core calls this method after an abort from the dialog the dialog can understand the abort occurred.  Also passed in an empty dictionary from the previous step to signal that the start of the step is configuration driven and not an abort.