### PR TITLE
Fix energy restore attr error

### DIFF
--- a/custom_components/span_panel/sensors/base.py
+++ b/custom_components/span_panel/sensors/base.py
@@ -416,10 +416,10 @@ class SpanEnergySensorBase(SpanSensorBase[T, D], RestoreSensor, ABC):
         return SpanEnergyExtraStoredData(
             native_value=(
                 float(self._attr_native_value)
-                if isinstance(self._attr_native_value, (int | float))
+                if isinstance(self._attr_native_value, int | float)
                 else None
             ),
-            native_unit_of_measurement=self._attr_native_unit_of_measurement,
+            native_unit_of_measurement=self.native_unit_of_measurement,
             last_valid_state=self._last_valid_state,
             last_valid_changed=(
                 self._last_valid_changed.isoformat() if self._last_valid_changed else None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes energy sensor restore by correcting numeric type check and using the public native_unit_of_measurement property to avoid attribute errors.
> 
> - **Energy sensors restore-state**:
>   - Fix numeric type check for `native_value` using `isinstance(..., int | float)`.
>   - Use `native_unit_of_measurement` property instead of `_attr_native_unit_of_measurement` to prevent restore-time attribute errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3496f3f38aeda6fe966730bb935bdfaef67ccba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->