### PR TITLE
chore(deps): bump span-panel-api to 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 - **Dashboard graph fidelity** — Circuit charts now use step interpolation instead of linear, eliminating misleading diagonal ramps between data points.
   Continuous signals (PV solar output, BESS SoC/SoE) retain linear interpolation to faithfully represent their gradual behavior.
 - **Panel status showing "Connected" while the panel is offline** — the panel status sensor now reflects the true connection state and updates within a second
-  of the panel going offline or coming back online (including the bump to span-panel-api v2.6.1)
+  of the panel going offline or coming back online (including the bump to span-panel-api v2.6.2)
 
 ## [2.0.5] - 4/2026
 

--- a/custom_components/span_panel/manifest.json
+++ b/custom_components/span_panel/manifest.json
@@ -22,7 +22,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "span-panel-api==2.6.1"
+    "span-panel-api==2.6.2"
   ],
   "version": "2.0.6",
   "zeroconf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.14.2,<3.15"
 dependencies = [
     "homeassistant==2026.4.2",
-    "span-panel-api==2.6.1",
+    "span-panel-api==2.6.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2407,7 +2407,7 @@ dev = [
 
 [[package]]
 name = "span-panel-api"
-version = "2.6.1"
+version = "2.6.2"
 source = { editable = "../span-panel-api" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bumps `span-panel-api` dependency from 2.6.1 to 2.6.2 in `manifest.json`, `pyproject.toml`, and `uv.lock`.
- Picks up the MQTT reconnect loop log-noise fix (SpanPanel/span-panel-api#137): offline-panel reconnect failures now log a one-line WARNING with the exception repr instead of a full paho/stdlib traceback; unexpected exceptions still include `exc_info=True` for support-ticket triage.
- Updates the 2.1.0-unreleased CHANGELOG entry to reference v2.6.2 instead of v2.6.1 in the panel-offline bullet.

## Test plan

- [ ] Integration loads against a live panel (no manifest-resolution errors on startup)
- [ ] Take panel offline — confirm the log shows a single-line WARNING (`Reconnect failed (ConnectionRefusedError(61, 'Connection refused')), retrying in 60.0s`) with no paho/stdlib stack frames
- [ ] Bring panel back online — confirm the grace period logic and reconnect behavior are unchanged